### PR TITLE
Fix Jenkins build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ------------ | -------------
 Travis       | [![Travis](https://travis-ci.org/doge-life/doge-application.svg?branch=master)](https://travis-ci.org/doge-life/doge-application)
 CircleCI     | [![CircleCI](https://circleci.com/gh/doge-life/doge-application.svg?style=svg)](https://circleci.com/gh/doge-life/doge-application)
-Jenkins      | [![Jenkins](http://ec2-107-21-21-140.compute-1.amazonaws.com/buildStatus/icon?job=doge-life/doge-application/add-jenkins-and-travis)](http://ec2-107-21-21-140.compute-1.amazonaws.com/job/doge-life/job/doge-application/job/add-jenkins-and-travis/)
+Jenkins      | [![Jenkins](http://ec2-107-21-21-140.compute-1.amazonaws.com/buildStatus/icon?job=doge-life/doge-application/master)](http://ec2-107-21-21-140.compute-1.amazonaws.com/job/doge-life/job/doge-application/job/master/)
 
 |            |             |
 ------------ | -------------


### PR DESCRIPTION
This was pointing at a dead branch instead of master