### PR TITLE
adding ubuntu user to docker configuration, removing 'as_root' hack

### DIFF
--- a/packer/packer.json
+++ b/packer/packer.json
@@ -10,6 +10,9 @@
             "type": "docker",
             "image": "ubuntu",
             "commit": true,
+            "changes": [
+                "USER ubuntu"
+            ],
             "run_command": [
                 "-d", "-it",
                 "-e", "PROXY_UNAME={{user `proxy_uname`}}",
@@ -34,6 +37,11 @@
             "type": "file",
             "source": "downloads",
             "destination": "/tmp"
+        },
+        {
+            "type": "shell",
+            "only": ["docker"],
+            "script": "scripts/add_ubuntu_user.sh"
         },
         {
             "type": "shell",

--- a/packer/scripts/add_ubuntu_user.sh
+++ b/packer/scripts/add_ubuntu_user.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+apt-get update
+apt-get install sudo
+rm -rf /var/lib/apt/lists/*
+
+echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu
+
+adduser --disabled-password --gecos '' ubuntu
+

--- a/packer/scripts/configure_proxy.sh
+++ b/packer/scripts/configure_proxy.sh
@@ -1,16 +1,8 @@
 #!/bin/bash -e
 
-function as_root() {
-    if [[ $EUID != 0 ]]; then
-        sudo -i "$@"
-    else
-        "$@"
-    fi
-}
-
 if [[ ! -z $PROXY_HOST ]]; then
     export http_proxy="http://$PROXY_UNAME:$PROXY_PASSWORD@$PROXY_HOST:$PROXY_PORT"
-    as_root echo "Acquire::http::Proxy \"http://$PROXY_UNAME:$PROXY_PASSWORD@$PROXY_HOST:$PROXY_PORT\";" \
+    sudo echo "Acquire::http::Proxy \"http://$PROXY_UNAME:$PROXY_PASSWORD@$PROXY_HOST:$PROXY_PORT\";" \
         > /etc/apt/apt.conf.d/00AscenaProxy
 else
     printf 'PROXY_HOST does not seem to have been set...\n'

--- a/packer/scripts/install_java.sh
+++ b/packer/scripts/install_java.sh
@@ -2,19 +2,12 @@
 
 JAVA_INSTALL_LOCATION="$HOME/java_install"
 
-function as_root() {
-    if [[ $EUID != 0 ]]; then
-        sudo -i "$@"
-    else
-        "$@"
-    fi
-}
-
 function download_java() {
     mkdir -p /tmp/downloads
     cd /tmp/downloads
-    as_root apt-get update
-    as_root apt-get install -y curl
+    sudo apt-get update
+    sudo apt-get install -y curl
+    sudo rm -rf /var/lib/apt/lists/*
     printf 'Downloading Java... (This might take a while)\n'
     curl -s -L -O -H "Cookie: oraclelicense=accept-securebackup-cookie" -k \
         "http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz"

--- a/packer/scripts/install_ruby.sh
+++ b/packer/scripts/install_ruby.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
 
-function as_root() {
-    if [[ $EUID != 0 ]]; then
-        sudo -i "$@"
-    else
-        "$@"
-    fi
-}
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get dist-upgrade -y
+sudo apt-get install -y ruby
+sudo rm -rf /var/lib/apt/lists/*
 
-as_root apt-get update
-as_root apt-get upgrade -y
-as_root apt-get dist-upgrade -y
-as_root apt-get install -y ruby

--- a/packer/scripts/serverspec.sh
+++ b/packer/scripts/serverspec.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
-function as_root() {
-    if [[ $EUID != 0 ]]; then
-        sudo -i "$@"
-    else
-        "$@"
-    fi
-}
-
 source $HOME/.bash_profile
-as_root gem install bundler --no-ri --no-rdoc
+sudo gem install bundler --no-ri --no-rdoc
 cd /tmp/tests
 bundle install
 bundle exec rake spec


### PR DESCRIPTION
Previously, we had added an `as_root` function to each of our shell scripts to get around the fact that docker by default did not provide the sudo package.  Now, we'll have environments that are more closely aligned in that the docker image will by default use the `ubuntu` user, and `sudo` now works for both images.