### PR TITLE
configure proxy first, rely on being root on docker at start

### DIFF
--- a/packer/packer.json
+++ b/packer/packer.json
@@ -41,12 +41,12 @@
         {
             "type": "shell",
             "only": ["docker"],
-            "script": "scripts/add_ubuntu_user.sh"
+            "script": "scripts/configure_proxy.sh"
         },
         {
             "type": "shell",
             "only": ["docker"],
-            "script": "scripts/configure_proxy.sh"
+            "script": "scripts/add_ubuntu_user.sh"
         },
         {
             "type": "shell",

--- a/packer/scripts/configure_proxy.sh
+++ b/packer/scripts/configure_proxy.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
+# This script is meant to be used with docker and is always run as root.
+
 if [[ ! -z $PROXY_HOST ]]; then
     export http_proxy="http://$PROXY_UNAME:$PROXY_PASSWORD@$PROXY_HOST:$PROXY_PORT"
-    sudo echo "Acquire::http::Proxy \"http://$PROXY_UNAME:$PROXY_PASSWORD@$PROXY_HOST:$PROXY_PORT\";" \
+    echo "Acquire::http::Proxy \"http://$PROXY_UNAME:$PROXY_PASSWORD@$PROXY_HOST:$PROXY_PORT\";" \
         > /etc/apt/apt.conf.d/00AscenaProxy
 else
     printf 'PROXY_HOST does not seem to have been set...\n'


### PR DESCRIPTION
`sudo` is unable to be installed via apt if we cannot connect to a proxy.  We cannot configure the proxy unless we are root.  We need to rely on the fact that we're root when the container starts up in order to add the proxy configuration.  (So that we can install `sudo`, so that we can be root.)