### PR TITLE
21 terraform deployment orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
+# Terraform
+
+.terraform
 
 .idea
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,8 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh ./terraform/providers/aws/us_east_1_dev/plan "${getAMIFromPackerManifest()}"
-                sh ./terraform/providers/aws/us_east_1_dev/apply "${getAMIFromPackerManifest()}"
+                sh "./terraform/providers/aws/us_east_1_dev/plan ${getAMIFromPackerManifest()}"
+                sh "./terraform/providers/aws/us_east_1_dev/apply ${getAMIFromPackerManifest()}"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,12 +32,12 @@ pipeline {
                 sh './gradlew build'
             }
         }
-        stage('Build and verify images') {
+        stage('Build and Verify Images') {
             steps {
                 sh './packer/build'
             }
         }
-        stage('Terraform') {
+        stage('Deploy to Dev') {
             when {
                 branch 'master'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,8 @@ def getAMIFromPackerManifest() {
     def workspace = pwd()
     def manifest = new File("${workspace}/packer/manifest.json")
     def json = new groovy.json.JsonSlurper().parseText(manifest.text)
-    json.builds.first().artifact_id
+    def ami_info = json.builds.first().artifact_id.split(':')
+    ami_info[1]
 }
 
 pipeline {
@@ -41,7 +42,8 @@ pipeline {
                 branch 'master'
             }
             steps {
-                echo "${getAMIFromPackerManifest()}"
+                sh ./terraform/providers/aws/us_east_1_dev/plan ${getAMIFromPackerManifest()}
+                sh ./terraform/providers/aws/us_east_1_dev/apply ${getAMIFromPackerManifest()}
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,8 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh ./terraform/providers/aws/us_east_1_dev/plan ${getAMIFromPackerManifest()}
-                sh ./terraform/providers/aws/us_east_1_dev/apply ${getAMIFromPackerManifest()}
+                sh ./terraform/providers/aws/us_east_1_dev/plan "${getAMIFromPackerManifest()}"
+                sh ./terraform/providers/aws/us_east_1_dev/apply "${getAMIFromPackerManifest()}"
             }
         }
     }

--- a/terraform/dev-env.tf
+++ b/terraform/dev-env.tf
@@ -1,0 +1,54 @@
+provider "aws" {
+  region     = "us-east-1"
+}
+
+resource "aws_instance" "doge-application-dev-env" {
+  ami           = "ami-1f389809"
+  instance_type = "t2.micro"
+	vpc_security_group_ids = ["${aws_security_group.doge-application-dev.id}"]
+	tags {
+    Name = "Doge Application - Development Environment"
+  }
+}
+
+resource "aws_security_group" "doge-application-dev" {
+  name = "doge-application-dev"
+
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+	ingress {
+		from_port = 8080
+		to_port = 8080
+		protocol = "TCP"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+	ingress {
+		from_port = 22
+		to_port = 22
+		protocol = "TCP"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+	egress {
+		from_port = 0
+		to_port = 0
+		protocol = "-1"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+}
+
+data "terraform_remote_state" "doge-application-dev-env-terraform-state" {
+    backend = "s3"
+    config {
+        bucket = "doge-application"
+        key = "terraform/dev-env-terraform.tfstate"
+        region = "us-east-1"
+    }
+}

--- a/terraform/providers/aws/us_east_1_dev/apply
+++ b/terraform/providers/aws/us_east_1_dev/apply
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+pushd `dirname "$0"`
+
+terraform apply -var ami_id=$1
+
+popd

--- a/terraform/providers/aws/us_east_1_dev/dev-env.tf
+++ b/terraform/providers/aws/us_east_1_dev/dev-env.tf
@@ -1,9 +1,11 @@
+variable "ami_id" {}
+
 provider "aws" {
   region     = "us-east-1"
 }
 
 resource "aws_instance" "doge-application-dev-env" {
-  ami           = "ami-1f389809"
+  ami           = "${var.ami_id}"
   instance_type = "t2.micro"
 	vpc_security_group_ids = ["${aws_security_group.doge-application-dev.id}"]
 	tags {

--- a/terraform/providers/aws/us_east_1_dev/dev-env.tf
+++ b/terraform/providers/aws/us_east_1_dev/dev-env.tf
@@ -43,12 +43,3 @@ resource "aws_security_group" "doge-application-dev" {
     }
 
 }
-
-data "terraform_remote_state" "doge-application-dev-env-terraform-state" {
-    backend = "s3"
-    config {
-        bucket = "doge-application"
-        key = "terraform/dev-env-terraform.tfstate"
-        region = "us-east-1"
-    }
-}

--- a/terraform/providers/aws/us_east_1_dev/dev-env.tf
+++ b/terraform/providers/aws/us_east_1_dev/dev-env.tf
@@ -1,37 +1,35 @@
 variable "ami_id" {}
 
 provider "aws" {
-  region     = "us-east-1"
+    region     = "us-east-1"
 }
 
 resource "aws_instance" "doge-application-dev-env" {
-  ami           = "${var.ami_id}"
-  instance_type = "t2.micro"
-	vpc_security_group_ids = ["${aws_security_group.doge-application-dev.id}"]
-	tags {
-    Name = "Doge Application - Development Environment"
-  }
+    ami           = "${var.ami_id}"
+    instance_type = "t2.micro"
+    vpc_security_group_ids = ["${aws_security_group.doge-application-dev.id}"]
+    tags { Name = "Doge Application - Development Environment" }
 }
 
 resource "aws_security_group" "doge-application-dev" {
-  name = "doge-application-dev"
+    name = "doge-application-dev"
 
-  ingress {
-    from_port = 80
-    to_port = 80
-    protocol = "TCP"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "TCP"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
 
 	ingress {
-		from_port = 8080
-		to_port = 8080
-		protocol = "TCP"
-		cidr_blocks = ["0.0.0.0/0"]
+	    from_port = 8080
+	    to_port = 8080
+	    protocol = "TCP"
+	    cidr_blocks = ["0.0.0.0/0"]
 	}
 
 	ingress {
-		from_port = 22
+	    from_port = 22
 		to_port = 22
 		protocol = "TCP"
 		cidr_blocks = ["0.0.0.0/0"]

--- a/terraform/providers/aws/us_east_1_dev/dev-env.tf
+++ b/terraform/providers/aws/us_east_1_dev/dev-env.tf
@@ -1,11 +1,11 @@
 variable "ami_id" {}
 
 provider "aws" {
-    region     = "us-east-1"
+    region = "us-east-1"
 }
 
 resource "aws_instance" "doge-application-dev-env" {
-    ami           = "${var.ami_id}"
+    ami = "${var.ami_id}"
     instance_type = "t2.micro"
     vpc_security_group_ids = ["${aws_security_group.doge-application-dev.id}"]
     tags { Name = "Doge Application - Development Environment" }
@@ -15,32 +15,32 @@ resource "aws_security_group" "doge-application-dev" {
     name = "doge-application-dev"
 
     ingress {
-        from_port = 80
-        to_port = 80
-        protocol = "TCP"
-        cidr_blocks = ["0.0.0.0/0"]
+      from_port = 80
+      to_port = 80
+      protocol = "TCP"
+      cidr_blocks = ["0.0.0.0/0"]
     }
 
-	ingress {
-	    from_port = 8080
-	    to_port = 8080
-	    protocol = "TCP"
-	    cidr_blocks = ["0.0.0.0/0"]
-	}
+    ingress {
+      from_port = 8080
+      to_port = 8080
+      protocol = "TCP"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
 
-	ingress {
-	    from_port = 22
-		to_port = 22
-		protocol = "TCP"
-		cidr_blocks = ["0.0.0.0/0"]
-	}
+    ingress {
+      from_port = 22
+      to_port = 22
+      protocol = "TCP"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
 
-	egress {
-		from_port = 0
-		to_port = 0
-		protocol = "-1"
-		cidr_blocks = ["0.0.0.0/0"]
-	}
+    egress {
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
 
 }
 

--- a/terraform/providers/aws/us_east_1_dev/plan
+++ b/terraform/providers/aws/us_east_1_dev/plan
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+pushd `dirname "$0"`
+
+terraform remote config -backend=S3 -backend-config="bucket=doge-application" -backend-config="key=dev-env-terraform.tfstate" -backend-config="region=us-east-1"
+
+terraform plan -var ami_id=$1
+
+popd

--- a/terraform/providers/aws/us_east_1_dev/plan
+++ b/terraform/providers/aws/us_east_1_dev/plan
@@ -2,7 +2,7 @@
 
 pushd `dirname "$0"`
 
-terraform remote config -backend=S3 -backend-config="bucket=doge-application" -backend-config="key=dev-env-terraform.tfstate" -backend-config="region=us-east-1"
+terraform remote config -backend=S3 -backend-config="bucket=doge-application" -backend-config="key=terraform/dev-env-terraform.tfstate" -backend-config="region=us-east-1"
 
 terraform plan -var ami_id=$1
 


### PR DESCRIPTION
Terraform configuration + Jenkinsfile step to deploy dev instance on a successful merge to `master`. Terraform file lives in /providers/aws/us-east-1-dev, like in [the hashicorp best practices](https://github.com/hashicorp/best-practices/tree/master/terraform/providers/aws). It is currently set up to take an ami_id as a parameter, configure a security group, store its own configuration in s3 and deploy the new instance. The Jenkinsfile will kick this process off on a successful merge to `master`.   