### PR TITLE
blow away the manifest file before building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,6 @@ pipeline {
         }
         stage('Build and Verify Images') {
             steps {
-                sh "rm -f ${workspace}/packer/manifest.json"
                 sh './packer/build'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
         }
         stage('Build and Verify Images') {
             steps {
+                sh "rm -f ${workspace}/packer/manifest.json"
                 sh './packer/build'
             }
         }

--- a/packer/build
+++ b/packer/build
@@ -2,6 +2,7 @@
 
 pushd `dirname "$0"`
 
+rm -f manifest.json
 packer build packer.json
 
 popd


### PR DESCRIPTION
Currently, the manifest.json isn't getting cleaned up between builds and Packer is appending new images to the list of builds. This PR will blow away the manifest of the current workspace before running `packer build`. This will guarantee only one image (the most recent) in the list of builds. 